### PR TITLE
Add alternative method to find Class::Init and fix a specific class injection issue

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.4.6</VersionPrefix>
+    <VersionPrefix>1.5.0</VersionPrefix>
     <Authors>BepInEx</Authors>
     <PackageOutputPath>../bin/NuGet</PackageOutputPath>
     <OutputPath Condition="'$(Configuration)' == 'Release'">../bin/$(MSBuildProjectName)</OutputPath>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>1.4.6</VersionPrefix>
+    <VersionPrefix>1.4.7</VersionPrefix>
     <Authors>BepInEx</Authors>
     <PackageOutputPath>../bin/NuGet</PackageOutputPath>
     <OutputPath Condition="'$(Configuration)' == 'Release'">../bin/$(MSBuildProjectName)</OutputPath>

--- a/Il2CppInterop.Common/Il2CppInterop.Common.csproj
+++ b/Il2CppInterop.Common/Il2CppInterop.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Disarm" Version="2022.1.0-master.36" />
+    <PackageReference Include="Disarm" Version="2022.1.0-master.57" />
     <PackageReference Include="Iced" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
@@ -13,13 +13,10 @@ public static class XrefScannerLowLevel
             if (instruction.Mnemonic == Arm64Mnemonic.RET && !ignoreRetn)
                 yield break;
 
-            if (instruction is
-                {
-                    // Check if jump or call instruction
-                    Mnemonic: Arm64Mnemonic.B or Arm64Mnemonic.BC or Arm64Mnemonic.BR or Arm64Mnemonic.BL or Arm64Mnemonic.BLR,
-                    MnemonicConditionCode: Arm64ConditionCode.NONE,
-                    FinalOpConditionCode: Arm64ConditionCode.NONE
-                })
+            var jump = instruction.Mnemonic is Arm64Mnemonic.B or Arm64Mnemonic.BC or Arm64Mnemonic.BR;
+            var call = instruction.Mnemonic is Arm64Mnemonic.BL or Arm64Mnemonic.BLR;
+
+            if ((jump || call) && instruction.MnemonicConditionCode == Arm64ConditionCode.NONE && instruction.FinalOpConditionCode == Arm64ConditionCode.NONE)
             {
                 var target = XrefScanUtilFinder.ExtractTargetAddress(instruction);
                 yield return (IntPtr)target;

--- a/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
+++ b/Il2CppInterop.Common/XrefScans/XrefScannerLowLevel.cs
@@ -13,10 +13,13 @@ public static class XrefScannerLowLevel
             if (instruction.Mnemonic == Arm64Mnemonic.RET && !ignoreRetn)
                 yield break;
 
-            var jump = instruction.Mnemonic is Arm64Mnemonic.B or Arm64Mnemonic.BC or Arm64Mnemonic.BR;
-            var call = instruction.Mnemonic is Arm64Mnemonic.BL or Arm64Mnemonic.BLR;
-
-            if ((jump || call) && instruction.MnemonicConditionCode == Arm64ConditionCode.NONE && instruction.FinalOpConditionCode == Arm64ConditionCode.NONE)
+            if (instruction is
+                {
+                    // Check if jump or call instruction
+                    Mnemonic: Arm64Mnemonic.B or Arm64Mnemonic.BC or Arm64Mnemonic.BR or Arm64Mnemonic.BL or Arm64Mnemonic.BLR,
+                    MnemonicConditionCode: Arm64ConditionCode.NONE,
+                    FinalOpConditionCode: Arm64ConditionCode.NONE
+                })
             {
                 var target = XrefScanUtilFinder.ExtractTargetAddress(instruction);
                 yield return (IntPtr)target;

--- a/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
+++ b/Il2CppInterop.Generator/Contexts/AssemblyRewriteContext.cs
@@ -9,9 +9,6 @@ namespace Il2CppInterop.Generator.Contexts;
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
 public class AssemblyRewriteContext
 {
-    // TODO: Dispose
-    private static readonly Dictionary<ModuleDefinition, RuntimeAssemblyReferences> ImportsMap = new();
-
     public readonly RewriteGlobalContext GlobalContext;
 
     public readonly RuntimeAssemblyReferences Imports;
@@ -30,7 +27,7 @@ public class AssemblyRewriteContext
         NewAssembly = newAssembly;
         GlobalContext = globalContext;
 
-        Imports = ImportsMap.GetOrCreate(newAssembly.ManifestModule!,
+        Imports = globalContext.ImportsMap.GetOrCreate(newAssembly.ManifestModule!,
             mod => new RuntimeAssemblyReferences(mod, globalContext));
     }
 

--- a/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
+++ b/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
@@ -19,6 +19,8 @@ public class RewriteGlobalContext : IDisposable
 
     internal readonly Dictionary<(object?, string, int), List<TypeDefinition>> RenameGroups = new();
 
+    internal readonly Dictionary<ModuleDefinition, RuntimeAssemblyReferences> ImportsMap = new();
+
     public RewriteGlobalContext(GeneratorOptions options, IIl2CppMetadataAccess gameAssemblies,
         IMetadataAccess unityAssemblies)
     {

--- a/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
+++ b/Il2CppInterop.Generator/Contexts/RewriteGlobalContext.cs
@@ -55,6 +55,7 @@ public class RewriteGlobalContext : IDisposable
     public IMetadataAccess UnityAssemblies { get; }
 
     public IEnumerable<AssemblyRewriteContext> Assemblies => myAssemblies.Values;
+    public AssemblyRewriteContext CorLib => myAssemblies["mscorlib"];
 
     internal bool HasGcWbarrierFieldWrite { get; set; }
 

--- a/Il2CppInterop.Generator/Il2CppInterop.Generator.csproj
+++ b/Il2CppInterop.Generator/Il2CppInterop.Generator.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.1" />
+    <PackageReference Include="AsmResolver.DotNet" Version="6.0.0-beta.2" />
     <PackageReference Include="MonoMod.Backports" Version="1.1.2">
       <Aliases>MonoModBackports</Aliases><!-- Transitive dependency from AsmResolver. Extern alias prevents it from affecting us. -->
     </PackageReference>

--- a/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
+++ b/Il2CppInterop.Generator/Passes/Pass16ScanMethodRefs.cs
@@ -10,8 +10,8 @@ namespace Il2CppInterop.Generator.Passes;
 
 public static class Pass16ScanMethodRefs
 {
-    public static readonly HashSet<long> NonDeadMethods = new();
-    public static IDictionary<long, List<XrefInstance>> MapOfCallers = new Dictionary<long, List<XrefInstance>>();
+    internal static HashSet<long> NonDeadMethods = new();
+    internal static IDictionary<long, List<XrefInstance>> MapOfCallers = new Dictionary<long, List<XrefInstance>>();
 
     public static void DoPass(RewriteGlobalContext context, GeneratorOptions options)
     {

--- a/Il2CppInterop.Generator/Passes/Pass61ImplementAwaiters.cs
+++ b/Il2CppInterop.Generator/Passes/Pass61ImplementAwaiters.cs
@@ -1,0 +1,94 @@
+﻿using System.Runtime.CompilerServices;
+using AsmResolver.DotNet;
+using AsmResolver.DotNet.Cloning;
+using AsmResolver.DotNet.Signatures;
+using AsmResolver.PE.DotNet.Cil;
+using AsmResolver.PE.DotNet.Metadata.Tables;
+using Il2CppInterop.Common;
+using Il2CppInterop.Generator.Contexts;
+using Microsoft.Extensions.Logging;
+
+namespace Il2CppInterop.Generator.Passes;
+
+public static class Pass61ImplementAwaiters
+{
+    public static void DoPass(RewriteGlobalContext context)
+    {
+        var corlib = context.CorLib;
+
+        var actionUntyped = corlib.GetTypeByName("System.Action");
+
+        var actionConversion = actionUntyped.NewType.Methods.Single(m => m.Name == "op_Implicit");
+
+        foreach (var assemblyContext in context.Assemblies)
+        {
+            // Use Lazy as a lazy way to not actually import the references until they're needed
+
+            Lazy<ITypeDefOrRef> actionUntypedRef = new(() => assemblyContext.NewAssembly.ManifestModule!.DefaultImporter.ImportType(actionConversion.Parameters[0].ParameterType.ToTypeDefOrRef())!);
+            Lazy<IMethodDefOrRef> actionConversionRef = new(() => assemblyContext.NewAssembly.ManifestModule!.DefaultImporter.ImportMethod(actionConversion));
+            Lazy<ITypeDefOrRef> notifyCompletionRef = new(() => assemblyContext.NewAssembly.ManifestModule!.DefaultImporter.ImportType(typeof(INotifyCompletion)));
+            var voidRef = assemblyContext.NewAssembly.ManifestModule!.CorLibTypeFactory.Void;
+
+            foreach (var typeContext in assemblyContext.Types)
+            {
+                // Odds are a majority of types won't implement any interfaces. Skip them to save time.
+                if (typeContext.OriginalType.IsInterface || typeContext.OriginalType.Interfaces.Count == 0)
+                    continue;
+
+                var iNotifyCompletion = typeof(INotifyCompletion);
+                var interfaceImplementation = typeContext.OriginalType.Interfaces.SingleOrDefault(interfaceImpl => interfaceImpl.Interface?.Namespace == iNotifyCompletion.Namespace && interfaceImpl.Interface?.Name == iNotifyCompletion.Name);
+                if (interfaceImplementation is null)
+                    continue;
+
+                var allOnCompleted = typeContext.Methods.Where(m => m.OriginalMethod.Name == nameof(INotifyCompletion.OnCompleted)).Select(mc => mc.NewMethod).ToArray();
+
+                // Conversion spits out an Il2CppSystem.Action, so look for methods that take that (and only that) in & return void, so the stack is balanced
+                // And use SignatureComparer because otherwise equality checks would fail due to the TypeSignatures being different references
+                var interopOnCompleted = allOnCompleted.FirstOrDefault(m => !m.IsStatic && m.Parameters.Count == 1 && m.Signature is not null && SignatureComparer.Default.Equals(m.Signature.ReturnType, voidRef) && SignatureComparer.Default.Equals(m.Signature.ParameterTypes[0], actionConversion.Signature?.ReturnType));
+
+                if (interopOnCompleted is null)
+                {
+                    var typeName = typeContext.OriginalType.FullName;
+                    var foundMethodCount = allOnCompleted.Length;
+                    Logger.Instance.LogInformation("Type {typeName} was found to implement INotifyCompletion, but no suitable method was found. {foundMethodCount} method(s) were found with the required name.", typeName, foundMethodCount);
+                    continue;
+                }
+
+                var onCompletedAttr = MethodAttributes.Public | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Virtual;
+                var sig = MethodSignature.CreateInstance(voidRef, [actionUntypedRef.Value.ToTypeSignature()]);
+
+                var proxyOnCompleted = new MethodDefinition(nameof(INotifyCompletion.OnCompleted), onCompletedAttr, sig);
+                var parameter = proxyOnCompleted.Parameters[0].GetOrCreateDefinition();
+                parameter.Name = "continuation";
+
+                var body = proxyOnCompleted.CilMethodBody ??= new(proxyOnCompleted);
+
+                typeContext.NewType.Interfaces.Add(new(notifyCompletionRef.Value));
+                typeContext.NewType.Methods.Add(proxyOnCompleted);
+
+                var instructions = body.Instructions;
+                instructions.Add(CilOpCodes.Ldarg_0); // load "this"
+                instructions.Add(CilOpCodes.Ldarg_1); // not static, so ldarg1 loads "continuation"
+                instructions.Add(CilOpCodes.Call, actionConversionRef.Value);
+
+                // The titular jump to the interop method -- it's gotta reference the method on the right type, so we need to handle generic parameters
+                // Without this, awaiters declared in generic types like UniTask<T>.Awaiter would effectively try to cast themselves to their untyped versions (UniTask<>.Awaiter in this case, which isn't a thing)
+                var genericParameterCount = typeContext.NewType.GenericParameters.Count;
+                if (genericParameterCount > 0)
+                {
+                    var typeArguments = Enumerable.Range(0, genericParameterCount).Select(i => new GenericParameterSignature(GenericParameterType.Type, i)).ToArray();
+                    var interopOnCompleteGeneric = typeContext.NewType.MakeGenericInstanceType(typeArguments)
+                        .ToTypeDefOrRef()
+                        .CreateMemberReference(interopOnCompleted.Name, interopOnCompleted.Signature);
+                    instructions.Add(CilOpCodes.Call, interopOnCompleteGeneric);
+                }
+                else
+                {
+                    instructions.Add(CilOpCodes.Call, interopOnCompleted);
+                }
+
+                instructions.Add(CilOpCodes.Ret);
+            }
+        }
+    }
+}

--- a/Il2CppInterop.Generator/Passes/Pass80UnstripMethods.cs
+++ b/Il2CppInterop.Generator/Passes/Pass80UnstripMethods.cs
@@ -200,9 +200,12 @@ public static class Pass80UnstripMethods
             if (resolvedElementType == null) return null;
             if (resolvedElementType.FullName == "System.String")
                 return imports.Il2CppStringArray;
-            var genericBase = resolvedElementType.IsValueType
-                ? imports.Il2CppStructArray
-                : imports.Il2CppReferenceArray;
+            var genericBase = resolvedElementType switch
+            {
+                GenericParameterSignature => imports.Il2CppArrayBase,
+                { IsValueType: true } => imports.Il2CppStructArray,
+                _ => imports.Il2CppReferenceArray
+            };
             return new GenericInstanceTypeSignature(genericBase.ToTypeDefOrRef(), false, resolvedElementType);
         }
 

--- a/Il2CppInterop.Generator/Passes/Pass81FillUnstrippedMethodBodies.cs
+++ b/Il2CppInterop.Generator/Passes/Pass81FillUnstrippedMethodBodies.cs
@@ -32,6 +32,9 @@ public static class Pass81FillUnstrippedMethodBodies
             }
         }
 
+        StuffToProcess.Clear();
+        StuffToProcess.Capacity = 0;
+
         Logger.Instance.LogInformation("IL unstrip statistics: {MethodsSucceeded} successful, {MethodsFailed} failed", methodsSucceeded,
             methodsFailed);
     }

--- a/Il2CppInterop.Generator/Runners/InteropAssemblyGenerator.cs
+++ b/Il2CppInterop.Generator/Runners/InteropAssemblyGenerator.cs
@@ -149,6 +149,11 @@ internal class InteropAssemblyGeneratorRunner : IRunner
             Pass60AddImplicitConversions.DoPass(rewriteContext);
         }
 
+        using (new TimingCookie("Implementing awaiters"))
+        {
+            Pass61ImplementAwaiters.DoPass(rewriteContext);
+        }
+
         using (new TimingCookie("Creating properties"))
         {
             Pass70GenerateProperties.DoPass(rewriteContext);

--- a/Il2CppInterop.Generator/Runners/InteropAssemblyGenerator.cs
+++ b/Il2CppInterop.Generator/Runners/InteropAssemblyGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using Il2CppInterop.Common;
+using Il2CppInterop.Common.XrefScans;
 using Il2CppInterop.Generator.Contexts;
 using Il2CppInterop.Generator.MetadataAccess;
 using Il2CppInterop.Generator.Passes;
@@ -199,6 +200,12 @@ internal class InteropAssemblyGeneratorRunner : IRunner
         using (new TimingCookie("Writing method pointer map"))
         {
             Pass91GenerateMethodPointerMap.DoPass(rewriteContext, options);
+        }
+
+        using (new TimingCookie("Clearing static data"))
+        {
+            Pass16ScanMethodRefs.MapOfCallers = new Dictionary<long, List<XrefInstance>>();
+            Pass16ScanMethodRefs.NonDeadMethods = [];
         }
 
         Logger.Instance.LogInformation("Done!");

--- a/Il2CppInterop.Runtime/Injection/ClassInjector.cs
+++ b/Il2CppInterop.Runtime/Injection/ClassInjector.cs
@@ -843,7 +843,7 @@ public static unsafe partial class ClassInjector
             body.Emit(OpCodes.Add_Ovf_Un);
             var nativeType = parameterInfo.ParameterType.NativeType();
             body.Emit(OpCodes.Ldobj, typeof(IntPtr));
-            if (nativeType != typeof(IntPtr))
+            if (nativeType != typeof(IntPtr) && !nativeType.IsByRef) // if it's a byref, we already have the pointer i think?
                 body.Emit(OpCodes.Ldobj, nativeType);
         }
 

--- a/Il2CppInterop.Runtime/Injection/Hooks/GarbageCollector_RunFinalizer_Patch.cs
+++ b/Il2CppInterop.Runtime/Injection/Hooks/GarbageCollector_RunFinalizer_Patch.cs
@@ -39,6 +39,13 @@ internal class GarbageCollector_RunFinalizer_Patch : Hook<GarbageCollector_RunFi
         },
         new()
         {
+            // Summer Vacation! Scramble - 2021.3.33 (x64)
+            pattern = "\x48\x89\x5c\x24\x10\x48\x89\x74\x24\x18\x57\x48\x83\xec\x20\x48\x8b\x19\x33\xff\x48\x89\x7c\x24\x30\x48\x8b\xf1\xf6\x83\x32\x01\x00\x00\x02\x75\x08\x48\x8b\xcb\xe8",
+            mask = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            xref = false,
+        },
+        new()
+        {
             // Test Game - 2021.3.22 (x64)
             pattern = "\x40\x53\x48\x83\xEC\x20\x48\x8B\xD9\x48\xC7\x44\x24\x30\x00\x00\x00\x00\x48\x8B",
             mask = "xxxxxxxxxxxxxxxxxxxx",

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -149,6 +149,16 @@ namespace Il2CppInterop.Runtime.Injection
         {
             static nint GetClassInitSubstitute()
             {
+                if (TryGetIl2CppExport(nameof(IL2CPP.il2cpp_array_new_specific), out nint arrayNewSpecific))
+                {
+                    // https://github.com/ByNameModding/BNM-Android/blob/3edeec43d74fc4392ba1b1eb9d5002e1b2ef2a67/src/Loading.cpp#L296
+                    var bnmClassInit = XrefScannerLowLevel.JumpTargets(XrefScannerLowLevel.JumpTargets(arrayNewSpecific).First()).First();
+                    if (bnmClassInit != IntPtr.Zero)
+                    {
+                        Logger.Instance.LogTrace("Used BNM Method to find Class::Init.");
+                        return bnmClassInit;
+                    }
+                }
                 if (TryGetIl2CppExport("mono_class_instance_size", out nint classInit))
                 {
                     Logger.Instance.LogTrace("Picked mono_class_instance_size as a Class::Init substitute");

--- a/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
+++ b/Il2CppInterop.Runtime/Injection/InjectorHelpers.cs
@@ -149,16 +149,6 @@ namespace Il2CppInterop.Runtime.Injection
         {
             static nint GetClassInitSubstitute()
             {
-                if (TryGetIl2CppExport(nameof(IL2CPP.il2cpp_array_new_specific), out nint arrayNewSpecific))
-                {
-                    // https://github.com/ByNameModding/BNM-Android/blob/3edeec43d74fc4392ba1b1eb9d5002e1b2ef2a67/src/Loading.cpp#L296
-                    var bnmClassInit = XrefScannerLowLevel.JumpTargets(XrefScannerLowLevel.JumpTargets(arrayNewSpecific).First()).First();
-                    if (bnmClassInit != IntPtr.Zero)
-                    {
-                        Logger.Instance.LogTrace("Used BNM Method to find Class::Init.");
-                        return bnmClassInit;
-                    }
-                }
                 if (TryGetIl2CppExport("mono_class_instance_size", out nint classInit))
                 {
                     Logger.Instance.LogTrace("Picked mono_class_instance_size as a Class::Init substitute");

--- a/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
+++ b/Il2CppInterop.Runtime/InteropTypes/Il2CppObjectBase.cs
@@ -84,8 +84,8 @@ public class Il2CppObjectBase
     private static readonly Type[] _intPtrTypeArray = { typeof(IntPtr) };
     private static readonly MethodInfo _getUninitializedObject = typeof(RuntimeHelpers).GetMethod(nameof(RuntimeHelpers.GetUninitializedObject))!;
     private static readonly MethodInfo _getTypeFromHandle = typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle))!;
-    private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(CreateGCHandle))!;
-    private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField(nameof(isWrapped))!;
+    private static readonly MethodInfo _createGCHandle = typeof(Il2CppObjectBase).GetMethod(nameof(CreateGCHandle), BindingFlags.Instance | BindingFlags.NonPublic)!;
+    private static readonly FieldInfo _isWrapped = typeof(Il2CppObjectBase).GetField(nameof(isWrapped), BindingFlags.Instance | BindingFlags.NonPublic)!;
 
     internal static class InitializerStore<T>
     {
@@ -112,7 +112,7 @@ public class Il2CppObjectBase
                 // However, it could be be user-made or implicit
                 // In that case we set the GCHandle and then call the ctor and let GC destroy any objects created by DerivedConstructorPointer
 
-                // var obj = (T)FormatterServices.GetUninitializedObject(type);
+                // var obj = (T)RuntimeHelpers.GetUninitializedObject(type);
                 il.Emit(OpCodes.Ldtoken, type);
                 il.Emit(OpCodes.Call, _getTypeFromHandle);
                 il.Emit(OpCodes.Call, _getUninitializedObject);
@@ -126,7 +126,7 @@ public class Il2CppObjectBase
                 // obj.isWrapped = true;
                 il.Emit(OpCodes.Dup);
                 il.Emit(OpCodes.Ldc_I4_1);
-                il.Emit(OpCodes.Stsfld, _isWrapped);
+                il.Emit(OpCodes.Stfld, _isWrapped);
 
                 var parameterlessConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, Type.EmptyTypes);
                 if (parameterlessConstructor != null)


### PR DESCRIPTION
The two issues i mention fixed class injection issues I faced when running Il2CppInterop with a custom fork of BepInEx for android. I also merged bepinex upstream into my fork, but I'm not sure how to cherrypick my commits for a PR.

## Class::Init 

I implemented an alternative method to find Class::Init, sourced from [BNM-Android](https://github.com/ByNameModding/BNM-Android/blob/3edeec43d74fc4392ba1b1eb9d5002e1b2ef2a67/src/Loading.cpp#L301), another Il2Cpp android modding project, This fixed issues with correctly initializing the vtable for the injected class.

## Class Injector IL generator change

This fixed invalid IL code when injecting a type that implemented an interface. IL generation failed for any method with an "out" parameter (aka by reference parameter). Adding a check for a "ByRef" type fixed this.

